### PR TITLE
Patch for v2 - Improve put_shared_message 

### DIFF
--- a/package_info.json
+++ b/package_info.json
@@ -1,4 +1,4 @@
 {
   "package_name": "th2-check2-recon",
-  "package_version": "2.4.6"
+  "package_version": "2.4.7"
 }

--- a/package_info.json
+++ b/package_info.json
@@ -1,4 +1,4 @@
 {
   "package_name": "th2-check2-recon",
-  "package_version": "2.4.1"
+  "package_version": "2.5.0"
 }

--- a/th2_check2_recon/recon.py
+++ b/th2_check2_recon/recon.py
@@ -88,4 +88,4 @@ class Recon:
         for rule in self.rules:
             groups = rule.description_of_groups_bridge()
             if shared_group_id in groups.keys() and MessageGroupType.shared in groups[shared_group_id]:
-                rule.process(new_message, attributes)
+                rule._process(new_message, attributes)

--- a/th2_check2_recon/reconcommon.py
+++ b/th2_check2_recon/reconcommon.py
@@ -35,8 +35,13 @@ class ReconMessage:
         try:
             return self._timestamp
         except AttributeError:
-            self._timestamp = MessageUtils.get_timestamp_ns(self.proto_message)
-            return self._timestamp
+            try:
+                self._timestamp = MessageUtils.get_timestamp_ns(self.proto_message)
+                return self._timestamp
+            except AttributeError:
+                # If proto_message is not protobuf.
+                self._timestamp = 0
+                return self._timestamp
 
     @staticmethod
     def get_info(info_dict: dict) -> str:

--- a/th2_check2_recon/rule.py
+++ b/th2_check2_recon/rule.py
@@ -117,7 +117,7 @@ class Rule:
     def process(self, message: ReconMessage, attributes: tuple, *args, **kwargs):
         self.group(message, attributes, *args, **kwargs)
         if message.group_id is None:
-            logger.info("RULE '%s': Ignored  %s", self.name, message.get_all_info())
+            logger.debug("RULE '%s': Ignored  %s", self.name, message.get_all_info())
             return
 
         self.hash(message, attributes, *args, **kwargs)


### PR DESCRIPTION
1. Add retransmit_msg method
2. Exclude group, hash and check_no_match_within_timeout methods 
execution from 'put_shared_message'
3. Set timestamp=0 if proto_message doesn't have metadata with a timestamp
4. Ignore messages with timestamp=0 when timeout checking